### PR TITLE
Add write permissions

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -2,8 +2,10 @@ name: Deploy MkDocs Site
 
 on:
   push:
-    branches:
-      - main  # Triggers deployment on push to the main branch
+    branches: ["main"]  # Triggers deployment on push to the main branch
+
+permissions:
+  contents: write  # Required to push to the gh-pages branch
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add `contents: write` permission to allow pushing to the `gh-pages` branch.