### PR TITLE
Create symlinks to model artifacts

### DIFF
--- a/src/nomad_auto_xrd/actions/analysis/activities.py
+++ b/src/nomad_auto_xrd/actions/analysis/activities.py
@@ -70,7 +70,8 @@ async def analyze(data: AnalyzeInput) -> AnalysisResult:
     finally:
         os.chdir(original_path)
         for link in created_symlinks:
-            os.unlink(link)
+            if os.path.exists(link):
+                os.unlink(link)
 
     return result
 

--- a/src/nomad_auto_xrd/actions/analysis/activities.py
+++ b/src/nomad_auto_xrd/actions/analysis/activities.py
@@ -37,21 +37,29 @@ async def analyze(data: AnalyzeInput) -> AnalysisResult:
                 trained_model_upload.upload_files.os_path,
                 'raw',
             )
-            trained_model_working_dir = (
-                data.analysis_settings.auto_xrd_model.working_directory
+            src_path = os.path.abspath(
+                os.path.join(
+                    trained_model_upload_raw_path,
+                    data.analysis_settings.auto_xrd_model.working_directory,
+                )
             )
-            os.symlink(
-                os.path.abspath(
-                    os.path.join(
-                        trained_model_upload_raw_path, trained_model_working_dir
+            dest_path = os.path.join(
+                upload_raw_path,
+                data.analysis_settings.auto_xrd_model.working_directory,
+            )
+            if os.path.exists(dest_path):
+                if os.path.islink(dest_path):
+                    os.unlink(dest_path)
+                else:
+                    raise FileExistsError(
+                        f'Cannot create symlink, path already exists: {dest_path}'
                     )
-                ),
-                os.path.join(upload_raw_path, trained_model_working_dir),
+            os.symlink(
+                src=src_path,
+                dst=dest_path,
                 target_is_directory=True,
             )
-            created_symlinks.append(
-                os.path.join(upload_raw_path, trained_model_working_dir)
-            )
+            created_symlinks.append(dest_path)
 
         os.chdir(upload_raw_path)
         os.makedirs(data.working_directory, exist_ok=True)


### PR DESCRIPTION
When the `upload_id` of the analysis ELN is different than that of the trained model being used, use `os.symlinks` to temporarily link the artifacts. The target path for the links corresponds to the expected path by the analysis routine, as if the model artifacts were present in the same upload.

## Summary by Sourcery

Link model artifacts from a different upload into the analysis folder for compatibility with the analysis routine, and remove those links after analysis completes.

New Features:
- Create temporary symbolic links to model artifact directories when the analysis upload ID differs from the model upload ID

Enhancements:
- Remove symlinks after analysis to clean up the workspace
- Update comment to clarify that analysis runs within the upload folder