### PR TITLE
Populate topology in analysis entries

### DIFF
--- a/src/nomad_auto_xrd/schema_packages/schema.py
+++ b/src/nomad_auto_xrd/schema_packages/schema.py
@@ -118,7 +118,7 @@ def populate_material_topology_with_cifs(
         system = System(
             atoms=nomad_atoms_from_ase_atoms(ase_atoms),
             label=label,
-            description='Reference structure used to train the auto-XRD model.',  # TODO make this more generic
+            description='Structure generated from a CIF file.',
             structural_type='bulk',
             dimensionality='3D',
             symmetry=symmetry,


### PR DESCRIPTION
Taking the identified phases of all the results, a unique set of systems is added to the `archive.results.material.topology` section. This can later be used to develop app filters for analysis entries based on identified systems.

## Summary by Sourcery

Factor out CIF-based material topology creation into a helper and integrate it into AutoXRDModel and analysis normalization to automatically populate and link material topology from identified phases.

New Features:
- Extract material topology population from CIF files into a reusable helper function
- Automatically populate archive.results.material.topology for analysis entries based on identified phases

Enhancements:
- Refactor AutoXRDModel.normalize to delegate topology building to the new helper and link reference structures to topology entries