### PR TITLE
Cleaning analysis settings

### DIFF
--- a/src/nomad_auto_xrd/common/analysis.py
+++ b/src/nomad_auto_xrd/common/analysis.py
@@ -783,7 +783,6 @@ def analyze(
             include_pdf=analysis_entry.analysis_settings.include_pdf,
             parallel=analysis_entry.analysis_settings.parallel,
             raw=analysis_entry.analysis_settings.raw,
-            show_individual=analysis_entry.analysis_settings.show_individual,
             wavelength=analysis_entry.analysis_settings.wavelength.to(
                 'angstrom'
             ).magnitude,

--- a/src/nomad_auto_xrd/common/analysis.py
+++ b/src/nomad_auto_xrd/common/analysis.py
@@ -779,7 +779,6 @@ def analyze(
             max_phases=analysis_entry.analysis_settings.max_phases,
             cutoff_intensity=analysis_entry.analysis_settings.cutoff_intensity,
             min_confidence=analysis_entry.analysis_settings.min_confidence,
-            unknown_threshold=analysis_entry.analysis_settings.unknown_threshold,
             show_reduced=analysis_entry.analysis_settings.show_reduced,
             include_pdf=analysis_entry.analysis_settings.include_pdf,
             parallel=analysis_entry.analysis_settings.parallel,

--- a/src/nomad_auto_xrd/common/analysis.py
+++ b/src/nomad_auto_xrd/common/analysis.py
@@ -278,10 +278,10 @@ def analyze_pattern(  # noqa: PLR0912, PLR0915
             settings.max_angle,
             settings.wavelength,
             save=False,
-            show_reduced=settings.show_reduced,
+            show_reduced=False,
             inc_pdf=settings.include_pdf,
             plot_both=False,
-            raw=settings.raw,
+            raw=False,
         )
 
     end = time.time()
@@ -649,10 +649,10 @@ class XRDAutoAnalyzer:
                     self.analysis_settings.max_angle,
                     self.analysis_settings.wavelength,
                     save=True,
-                    show_reduced=self.analysis_settings.show_reduced,
+                    show_reduced=False,
                     inc_pdf=self.analysis_settings.include_pdf,
                     plot_both=False,
-                    raw=self.analysis_settings.raw,
+                    raw=False,
                     rietveld=False,
                 )
                 merged_results.plot_paths = [
@@ -779,10 +779,8 @@ def analyze(
             max_phases=analysis_entry.analysis_settings.max_phases,
             cutoff_intensity=analysis_entry.analysis_settings.cutoff_intensity,
             min_confidence=analysis_entry.analysis_settings.min_confidence,
-            show_reduced=analysis_entry.analysis_settings.show_reduced,
             include_pdf=analysis_entry.analysis_settings.include_pdf,
             parallel=analysis_entry.analysis_settings.parallel,
-            raw=analysis_entry.analysis_settings.raw,
             wavelength=analysis_entry.analysis_settings.wavelength.to(
                 'angstrom'
             ).magnitude,

--- a/src/nomad_auto_xrd/common/models.py
+++ b/src/nomad_auto_xrd/common/models.py
@@ -85,7 +85,6 @@ class AnalysisSettingsInput:
     max_phases: int
     cutoff_intensity: float
     min_confidence: float
-    unknown_threshold: float
     show_reduced: bool
     include_pdf: bool
     parallel: bool

--- a/src/nomad_auto_xrd/common/models.py
+++ b/src/nomad_auto_xrd/common/models.py
@@ -85,10 +85,8 @@ class AnalysisSettingsInput:
     max_phases: int
     cutoff_intensity: float
     min_confidence: float
-    show_reduced: bool
     include_pdf: bool
     parallel: bool
-    raw: bool
     wavelength: float
     min_angle: float
     max_angle: float

--- a/src/nomad_auto_xrd/common/models.py
+++ b/src/nomad_auto_xrd/common/models.py
@@ -89,7 +89,6 @@ class AnalysisSettingsInput:
     include_pdf: bool
     parallel: bool
     raw: bool
-    show_individual: bool
     wavelength: float
     min_angle: float
     max_angle: float

--- a/src/nomad_auto_xrd/schema_packages/schema.py
+++ b/src/nomad_auto_xrd/schema_packages/schema.py
@@ -559,14 +559,6 @@ class AnalysisSettings(ArchiveSection):
             component=ELNComponentEnum.NumberEditQuantity,
         ),
     )
-    show_reduced = Quantity(
-        type=bool,
-        description='Flag to show reduced patterns.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.BoolEditQuantity,
-        ),
-    )
     include_pdf = Quantity(
         type=bool,
         description='Flag to include PDFs in the analysis.',
@@ -578,14 +570,6 @@ class AnalysisSettings(ArchiveSection):
     parallel = Quantity(
         type=bool,
         description='Flag to run the analysis in parallel.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.BoolEditQuantity,
-        ),
-    )
-    raw = Quantity(
-        type=bool,
-        description='Flag to show raw data.',
         default=False,
         a_eln=ELNAnnotation(
             component=ELNComponentEnum.BoolEditQuantity,
@@ -1702,10 +1686,8 @@ class AutoXRDAnalysisAction(Action):
                 max_phases=self.analysis_settings.max_phases,
                 cutoff_intensity=self.analysis_settings.cutoff_intensity,
                 min_confidence=self.analysis_settings.min_confidence,
-                show_reduced=self.analysis_settings.show_reduced,
                 include_pdf=self.analysis_settings.include_pdf,
                 parallel=self.analysis_settings.parallel,
-                raw=self.analysis_settings.raw,
                 wavelength=self.analysis_settings.wavelength.to('angstrom').magnitude,
                 min_angle=self.analysis_settings.min_angle.to('degree').magnitude,
                 max_angle=self.analysis_settings.max_angle.to('degree').magnitude,

--- a/src/nomad_auto_xrd/schema_packages/schema.py
+++ b/src/nomad_auto_xrd/schema_packages/schema.py
@@ -559,14 +559,6 @@ class AnalysisSettings(ArchiveSection):
             component=ELNComponentEnum.NumberEditQuantity,
         ),
     )
-    unknown_threshold = Quantity(
-        type=float,
-        description='Threshold for unknown phase identification.',
-        default=0.2,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.NumberEditQuantity,
-        ),
-    )
     show_reduced = Quantity(
         type=bool,
         description='Flag to show reduced patterns.',
@@ -1718,7 +1710,6 @@ class AutoXRDAnalysisAction(Action):
                 max_phases=self.analysis_settings.max_phases,
                 cutoff_intensity=self.analysis_settings.cutoff_intensity,
                 min_confidence=self.analysis_settings.min_confidence,
-                unknown_threshold=self.analysis_settings.unknown_threshold,
                 show_reduced=self.analysis_settings.show_reduced,
                 include_pdf=self.analysis_settings.include_pdf,
                 parallel=self.analysis_settings.parallel,

--- a/src/nomad_auto_xrd/schema_packages/schema.py
+++ b/src/nomad_auto_xrd/schema_packages/schema.py
@@ -591,14 +591,6 @@ class AnalysisSettings(ArchiveSection):
             component=ELNComponentEnum.BoolEditQuantity,
         ),
     )
-    show_individual = Quantity(
-        type=bool,
-        description='Flag to shows individual prediction results: XRD and PDF.',
-        default=False,
-        a_eln=ELNAnnotation(
-            component=ELNComponentEnum.BoolEditQuantity,
-        ),
-    )
     wavelength = Quantity(
         type=float,
         unit='m',
@@ -1714,7 +1706,6 @@ class AutoXRDAnalysisAction(Action):
                 include_pdf=self.analysis_settings.include_pdf,
                 parallel=self.analysis_settings.parallel,
                 raw=self.analysis_settings.raw,
-                show_individual=self.analysis_settings.show_individual,
                 wavelength=self.analysis_settings.wavelength.to('angstrom').magnitude,
                 min_angle=self.analysis_settings.min_angle.to('degree').magnitude,
                 max_angle=self.analysis_settings.max_angle.to('degree').magnitude,

--- a/src/nomad_auto_xrd/schema_packages/schema.py
+++ b/src/nomad_auto_xrd/schema_packages/schema.py
@@ -528,6 +528,24 @@ class AnalysisSettings(ArchiveSection):
     A schema for the settings for running the analysis.
     """
 
+    m_def = Section(
+        a_eln=ELNAnnotation(
+            properties=SectionProperties(
+                order=[
+                    'auto_xrd_model',
+                    'min_angle',
+                    'max_angle',
+                    'wavelength',
+                    'max_phases',
+                    'min_confidence',
+                    'cutoff_intensity',
+                    'include_pdf',
+                    'parallel',
+                    'simulated_reference_patterns',
+                ]
+            )
+        )
+    )
     auto_xrd_model = Quantity(
         type=AutoXRDModel,
         a_eln=ELNAnnotation(
@@ -538,15 +556,16 @@ class AnalysisSettings(ArchiveSection):
     max_phases = Quantity(
         type=int,
         description='Maximum number of phases to identify.',
-        default=5,
+        default=3,
         a_eln=ELNAnnotation(
             component=ELNComponentEnum.NumberEditQuantity,
         ),
     )
     cutoff_intensity = Quantity(
         type=float,
-        description='Cutoff intensity for the XRD pattern.',
-        default=0.05,
+        description='Intensity threshold (% of original maximum) below which phase '
+        'identification stops, assuming remaining signal is noise.',
+        default=10.0,
         a_eln=ELNAnnotation(
             component=ELNComponentEnum.NumberEditQuantity,
         ),
@@ -561,7 +580,7 @@ class AnalysisSettings(ArchiveSection):
     )
     include_pdf = Quantity(
         type=bool,
-        description='Flag to include PDFs in the analysis.',
+        description='Whether to include the PDF based model in the analysis.',
         default=True,
         a_eln=ELNAnnotation(
             component=ELNComponentEnum.BoolEditQuantity,
@@ -569,7 +588,7 @@ class AnalysisSettings(ArchiveSection):
     )
     parallel = Quantity(
         type=bool,
-        description='Flag to run the analysis in parallel.',
+        description='Whether to run the analysis using a parallel processing pool.',
         default=False,
         a_eln=ELNAnnotation(
             component=ELNComponentEnum.BoolEditQuantity,

--- a/tests/data/auto_xrd_analysis.archive.json
+++ b/tests/data/auto_xrd_analysis.archive.json
@@ -9,10 +9,8 @@
             "cutoff_intensity": 1,
             "min_confidence": 40,
             "wavelength": "CuKa",
-            "show_reduced": false,
             "include_pdf": false,
             "parallel": false,
-            "raw": true,
             "min_angle": 25,
             "max_angle": 80,
             "structure_references_directory": "References"

--- a/tests/data/auto_xrd_analysis.archive.json
+++ b/tests/data/auto_xrd_analysis.archive.json
@@ -9,12 +9,10 @@
             "cutoff_intensity": 1,
             "min_confidence": 40,
             "wavelength": "CuKa",
-            "unknown_threshold": 25,
             "show_reduced": false,
             "include_pdf": false,
             "parallel": false,
             "raw": true,
-            "show_individual": false,
             "min_angle": 25,
             "max_angle": 80,
             "structure_references_directory": "References"


### PR DESCRIPTION
## Summary by Sourcery

Clean up analysis settings schema and related code by removing obsolete parameters, defining ELN field order, adjusting defaults, and simplifying analysis function calls.

Enhancements:
- Define explicit ELN property ordering for AnalysisSettings.
- Remove obsolete settings (unknown_threshold, show_reduced, raw, show_individual) from schema, models, and analysis functions.
- Adjust default max_phases from 5 to 3 and cutoff_intensity from 0.05 to 10.0 with updated description.
- Update include_pdf and parallel settings and ensure analysis routines disable show_reduced and raw flags by default.

Tests:
- Update test archive JSON fixture to reflect schema changes.